### PR TITLE
Debug output clarification

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,19 +19,14 @@
             "request": "launch",
             "program": "${workspaceFolder}/a.out",
             "args": [],
-            "stopAtEntry": true,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "miDebuggerPath": "/usr/bin/gdb",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                }
-            ],
+            "stopAtEntry": true,
+            "logging": {
+                "moduleLoad": false
+            },
+            "miDebuggerArgs": "--quiet",
+            "targetArchitecture": "x64",
             "preLaunchTask": "compilation"
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,12 +6,17 @@
         {
             "label": "compilation",
             "type": "shell",
-            "command": "gcc -g main.c -lm",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$gcc",
+            "osx":{
+                "command": "clang --debug main.c"
+            },
+            "linux": {
+                "command": "gcc --debug main.c -lm"
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Modèle de départ pour exercices d'introduction à Visual Studio Code, au débo
 1. Pour travailler sous MacOS, installez aussi Xcode et l'extension `CodeLLDB` pour Visual Studio Code.
     - Installez Xcode via le App Store.
     - Installez "Xcode Command Line Tools". À l'invite de commandes: `> xcode-select --install`
-    - https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb
+    - https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb <!-- Mesure temporaire tant que https://github.com/microsoft/vscode-cpptools/issues/3829 n'est pas résolu. -->
 1. Compilez une première fois le programme.
     - Menu: `View` > `Command Palette` > `Tasks: Run Build Task`
 1. Executez une première fois le programme avec le débogueur.
@@ -33,8 +33,13 @@ Modèle de départ pour exercices d'introduction à Visual Studio Code, au débo
     - Choisissez la cible correspondant à votre system opérateur.
         - Menu déroulant `DEBUG`: {`test (Linux)`, `test (MacOS)`}
     - Menu: `Debug` > `Start debugging`
-    - Vous devriez voir dans l'onglet `DEBUG CONSOLE` le résultat suivant:
-        - `Launching: [chemin d'acces]/a.out Process exited with code 23.`
+1. Vous devriez observer dans l'onglet `DEBUG CONSOLE` le résultat suivant:
+    - Sous Linux: 
+        - `[Inferior 1 (process [NNNN]) exited with code 027]`.
+        - Attention, le débogueur `gdb` affiche le code de retour en octal (base 8). Ici, `027` en octal est `23` en décimal.
+    - Sous MacOS: 
+        - `Launching: [chemin d'acces]/a.out`
+        - `Process exited with code 23.`
 
 Vous pouvez voir la valeur retournée par le programme dans l'onglet `DEBUG CONSOLE` comme décrit ci-haut.
 Vous pouvez aussi voir la valeur retournée par le dernier programme lancé à l'invite de commandes avec `echo $?`.
@@ -83,3 +88,4 @@ Par contre, sur Internet, les questions d'étudiant se reniflent de loin alors s
 #### Où demander de l'aide
 1. stackoverflow.com
 1. reddit.com/r/codinghelp
+


### PR DESCRIPTION
Clarifies what is to be observed when the program is first compiled and run depending under which OS we are working. It will be different because we're using two different debugging extensions for Linux and macOS with different outputs. 

The reason we're using different extensions is because of this bug: https://github.com/microsoft/vscode-cpptools/issues/3829. Hopefully, that issue will be resolved eventually. It cropped up when Catalina was released.

More parameters were added or modified to the `test (Linux)` configuration to prune away as much unnecessary verbosity as possible.